### PR TITLE
Changed the Javadoc URL to point to latest

### DIFF
--- a/_posts/2016-05-19-docs.md
+++ b/_posts/2016-05-19-docs.md
@@ -8,4 +8,4 @@ fa-icon: cogs
 * [Getting started](https://github.com/awaitility/awaitility/wiki/Getting_started)
 * [Usage Guide](https://github.com/awaitility/awaitility/wiki/Usage)
 * [Downloads](https://github.com/awaitility/awaitility/wiki/Downloads)
-* [Awaitility Javadoc](http://www.javadoc.io/doc/org.awaitility/awaitility/2.0.0)
+* [Awaitility Javadoc](http://www.javadoc.io/doc/org.awaitility/awaitility/latest)


### PR DESCRIPTION
This is a tiny fix for https://github.com/awaitility/awaitility.github.io/issues/4 

I just changed the URL to point to javadoc.io latest javadoc 